### PR TITLE
Remove hardcoded JRE type

### DIFF
--- a/_api_/.classpath
+++ b/_api_/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
This change accidentally got added in my previous commit.  I was trying to see if there was a way we could parameterize this classpath entry.  Something like this:

```
<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/_ee_"/>
```

Where _ee_ would be expanded out to whatever the developer had set in the enroute.bnd file

```
-runee: JavaSE-1.7
```

Then whatever was there would be expanded in the .classpath files.  
