### PR TITLE
Missing opening quote on icon link

### DIFF
--- a/_application_/static/_pid_/index.html
+++ b/_application_/static/_pid_/index.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="">
-<link rel="icon" href=/_pid_/favicon.ico">
+<link rel="icon" href="/_pid_/favicon.ico">
 
 <title>_PROJECT_</title>
 


### PR DESCRIPTION
Hello!
 Here is a trivial fix to make html header valid...

Best regards
  --Henryk Paluch